### PR TITLE
Add marketplace manifests so Cursor's add-plugin folder flow works

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "productos",
+  "owner": {
+    "name": "Chris Ashby",
+    "email": "chris@telescope.design"
+  },
+  "metadata": {
+    "description": "ProductOS — a complete operating system for taking a product from idea to revenue with AI agents."
+  },
+  "plugins": [
+    {
+      "name": "productos",
+      "source": "./",
+      "description": "Four phases (Define, Design, Develop, Distribute) with checklists, templates, and 35 skills that take a product from idea to revenue."
+    }
+  ]
+}

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "productos",
+  "owner": {
+    "name": "Chris Ashby",
+    "email": "chris@telescope.design"
+  },
+  "metadata": {
+    "description": "ProductOS — a complete operating system for taking a product from idea to revenue with AI agents."
+  },
+  "plugins": [
+    {
+      "name": "productos",
+      "source": ".",
+      "description": "Four phases (Define, Design, Develop, Distribute) with checklists, templates, and 35 skills that take a product from idea to revenue."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes the error Cursor shows when pointing `/add-plugin` at the downloaded folder:

> Could not add plugins from the selected folder: No marketplace manifest found in … (expected .cursor-plugin/marketplace.json or .claude-plugin/marketplace.json)

Cursor's folder-add flow treats the selected folder as a **marketplace root** — a per-plugin `plugin.json` alone isn't enough (same pattern we hit with Codex in #1). This adds single-entry marketplace manifests pointing at the repo root itself:

- **`.cursor-plugin/marketplace.json`** — validates against the official `marketplace.schema.json` from [cursor/plugins](https://github.com/cursor/plugins).
- **`.claude-plugin/marketplace.json`** — same for Claude Code's `/plugin marketplace add` flow; passes `claude plugin validate --strict`.

## Validation

- Cursor marketplace manifest validated against the official JSON Schema.
- Claude marketplace manifest passes strict validation, and the full flow was tested end-to-end with the Claude CLI: `claude plugin marketplace add <repo>` → `claude plugin install productos@productos` → plugin installed and enabled at v1.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WY5Ctqnp6p8Ydrt1ckCYgx

---
_Generated by [Claude Code](https://claude.ai/code/session_01WY5Ctqnp6p8Ydrt1ckCYgx)_